### PR TITLE
fix(migrations): fix sql quires to run on SQLite

### DIFF
--- a/general_reports/migrations/0001_initial.py
+++ b/general_reports/migrations/0001_initial.py
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.RunSQL(
-            """create or replace view profitability_view as
+            """drop view if exists profitability_view; create view profitability_view as
             select 'expensetransaction' as type, date, value
             from expense_expensetransaction
             union all

--- a/purchase/migrations/0002_productinoutdbview.py
+++ b/purchase/migrations/0002_productinoutdbview.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
         ),
         migrations.RunSQL(
             """
-                    create or replace view product_in_out_view as
+                    drop view if exists  product_in_out_view; create view product_in_out_view as
                     select id, date,  'sale' as doc_type, product_id,quantity , price, value from sales_sale
                     union all
                     select id , date, 'purchase' as doc_type , quantity , product_id, price, value from purchase_purchase 


### PR DESCRIPTION
I faced errors when trying to run migrations because SQLite does not support the `CREATE OR REPLACE` syntax.
The default DB for this demo project is SQLite, so I fixed the SQL queries to work on SQLite.


* fix SQL quires to run on SQLite